### PR TITLE
Provide backward compatibility for url template tag for Django < 1.5

### DIFF
--- a/django_jasmine/templates/jasmine/base.html
+++ b/django_jasmine/templates/jasmine/base.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <!doctype html>
 
 <html>


### PR DESCRIPTION
For Django < 1.5 load url library from future
Tested in Django 1.4
