### PR TITLE
Support for django 1.5 and higher

### DIFF
--- a/django_jasmine/urls.py
+++ b/django_jasmine/urls.py
@@ -1,6 +1,10 @@
 import os
+import django
 
-from django.conf.urls.defaults import *
+if django.VERSION >= (1, 5):
+    from django.conf.urls import patterns, url
+else:
+    from django.conf.urls.defaults import *
 from django.conf import settings
 
 from views import run_tests


### PR DESCRIPTION
Django 1.5 and higher don't have django.conf.urls.defaults which was deprecated.
