### PR TITLE
Add jasmine_preload block in base template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,10 @@ jasmine reporter), you can create a jasmine/index.html template as follow::
 
     {% extends "jasmine/base.html" %}
 
+    {% block jasmine_preload %}
+        {# If you need to do any setup before dependencies in files.json are loaded (like define app namespace) #}
+    {% endblock %}
+
     {% block jasmine_extra %}
         {# If you want to extend the default jasmineEnv config #}
     {% endblock %}

--- a/django_jasmine/templates/jasmine/base.html
+++ b/django_jasmine/templates/jasmine/base.html
@@ -12,6 +12,8 @@
     <script  src="{{ STATIC_URL }}jasmine-latest/jasmine-html.js"></script>
     <script  src="{{ STATIC_URL }}jasmine-jquery-latest.js"></script>
 
+    {% block jasmine_preload %}{% endblock %}
+
     {# source files #}
     {% for url in suite.js_files %}
     <script src="{{ url }}"></script>


### PR DESCRIPTION
I found myself needing to define the global namespace for our app before my libraries were pulled in. The most self-contained solution seemed to be to allow a block in the head tag where this kind of setup can be performed.

Is this a reasonable solution? I'm very new to jasmine and this module, so if there is a better way let me know.
