### PR TITLE
Python3 relative import fix

### DIFF
--- a/django_jasmine/urls.py
+++ b/django_jasmine/urls.py
@@ -7,7 +7,7 @@ else:
     from django.conf.urls.defaults import *
 from django.conf import settings
 
-from views import run_tests
+from .views import run_tests
 
 static_root = os.path.join(os.path.dirname(__file__), 'static')
 


### PR DESCRIPTION
This allows django_jasmine to work with Python3.

Tested on 2.7, 3.2 and 3.3
