### PR TITLE
Remove repeated tests on python versions from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
 install:
     - pip install tox-travis python-coveralls


### PR DESCRIPTION
* Tox already checks for {py27,py34,py35,py36} and the same need
not repeat in travis